### PR TITLE
Remove orange focus on Toolbar on Ubuntu Fixes #5

### DIFF
--- a/roastero/static/mainStyle.css
+++ b/roastero/static/mainStyle.css
@@ -23,6 +23,7 @@ QPushButton#toolbar {
     margin: 15px 5px 3px 5px;
     font-size: 12px;
     background-color: none;
+    outline: none;
 }
 
 QPushButton#toolbar:disabled {


### PR DESCRIPTION
This is not a Qt CSS problem, but normal behavior of Ubuntu system styling. Default Ubuntu theme Ambiance enhances focused elements with an orange inner rectangle. https://stackoverflow.com/a/17297035