### PR TITLE
Updated fix for Ubuntu button select-state style

### DIFF
--- a/roastero/static/mainStyle.css
+++ b/roastero/static/mainStyle.css
@@ -23,7 +23,6 @@ QPushButton#toolbar {
     margin: 15px 5px 3px 5px;
     font-size: 12px;
     background-color: none;
-    outline: none;
 }
 
 QPushButton#toolbar:disabled {
@@ -67,6 +66,7 @@ QPushButton {
     font-family: "Asap";
     font: bold;
     font-size: 12px;
+    outline: none;
 }
 
 QPushButton:disabled {


### PR DESCRIPTION
Moved button style fix to the QPushButton global style. Fixes orange Ubuntu button select state in other places, instead of just the main menu (all buttons in the Recipes tab and Recipes Editor window)