### PR TITLE
Fix config.ini copy function so program works on the first run

### DIFF
--- a/roastero/roastero.py
+++ b/roastero/roastero.py
@@ -35,7 +35,7 @@ def check_for_user_folder():
     if not os.path.isdir(roasteroUserFolder):
         shutil.copytree("recipes", os.path.join(roasteroUserFolder, "recipes"))
         shutil.copytree("log", os.path.join(roasteroUserFolder, "log"))
-        shutil.copyfile("config.ini", roasteroUserFolder)
+        shutil.copyfile("config.ini", os.path.join(roasteroUserFolder, "config.ini"))
 
 # Check for user folder.
 check_for_user_folder()


### PR DESCRIPTION
The first time Roastero was run on a new system, it failed because it was trying to copy config.ini to ~/Documents/Roastero rather than to ~/Documents/Roastero/config.ini.  copyfile needs the full path including the filename, not just a directory.
